### PR TITLE
Added appsettings key for custom executable path

### DIFF
--- a/Tests/Codaxy.WkHtmlToPdf.Tests/Codaxy.WkHtmlToPdf.Tests.csproj
+++ b/Tests/Codaxy.WkHtmlToPdf.Tests/Codaxy.WkHtmlToPdf.Tests.csproj
@@ -35,6 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/Tests/Codaxy.WkHtmlToPdf.Tests/PdfConvert.cs
+++ b/Tests/Codaxy.WkHtmlToPdf.Tests/PdfConvert.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Web;
 using System.Threading;
 using System.Collections.Generic;
+using System.Configuration;
 
 namespace Codaxy.WkHtmlToPdf
 {
@@ -71,8 +72,14 @@ namespace Codaxy.WkHtmlToPdf
 
         private static string GetWkhtmlToPdfExeLocation()
         {
+            string customPath = ConfigurationManager.AppSettings["wkhtmltopdf:path"];
+            string filePath = Path.Combine(customPath, @"wkhtmltopdf.exe");
+
+            if (File.Exists(filePath))
+                return filePath;
+
             string programFilesPath = System.Environment.GetEnvironmentVariable("ProgramFiles");
-            string filePath = Path.Combine(programFilesPath, @"wkhtmltopdf\wkhtmltopdf.exe");
+            filePath = Path.Combine(programFilesPath, @"wkhtmltopdf\wkhtmltopdf.exe");
 
             if (File.Exists(filePath))
                 return filePath;


### PR DESCRIPTION
Referenced the ConfigurationManager, added a key for an app setting to configure the wkhtmltopdf executable.
Changed the file location method to first look for the file in the configured folder.